### PR TITLE
[build] Fix building with newer binutils

### DIFF
--- a/callback.S
+++ b/callback.S
@@ -47,8 +47,8 @@
 /** Paging bit in CR0 */
 #define CR0_PG 0x80000000
 
-	.arch	i386
 	.code32
+	.arch	i386
 
 	/* Call an arbitrary real-mode function */
 	.section ".text", "ax", @progbits

--- a/startup.S
+++ b/startup.S
@@ -31,8 +31,8 @@
 #define KC_CMD 0x64
 #define KC_CMD_RESET 0xfe
 
-	.arch	i386
 	.code32
+	.arch	i386
 
 	/* Startup code */
 	.section ".text", "ax", @progbits


### PR DESCRIPTION
Newer versions of the GNU assembler (observed with binutils 2.41) will
complain about the ".arch i386" in files assembled with "as --64",
with the message "Error: 64bit mode not supported on 'i386'".
see [https://github.com/ipxe/ipxe/commit/6ca597eee](url)